### PR TITLE
feat: add ERC2362 compliant wrapper

### DIFF
--- a/.soliumrc.json
+++ b/.soliumrc.json
@@ -5,6 +5,7 @@
     "quotes": ["error", "double"],
     "indentation": ["error", 2],
     "linebreak-style": ["error", "unix"],
-    "error-reason": "off"
+    "error-reason": "off",
+    "security/no-block-members": "off"
   }
 }

--- a/contracts/Migrations.sol
+++ b/contracts/Migrations.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.0;
+pragma solidity 0.6.6;
 
 
 contract Migrations {

--- a/contracts/PriceFeed.sol
+++ b/contracts/PriceFeed.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.0;
+pragma solidity 0.6.6;
 pragma experimental ABIEncoderV2;
 
 // Import the UsingWitnet library that enables interacting with Witnet
@@ -26,7 +26,7 @@ contract PriceFeed is UsingWitnet {
     request = new BitcoinPriceRequest();
   }
 
-  function requestUpdate() public payable {
+  function requestUpdate() external payable {
     require(!pending, "An update is already pending. Complete it first before requesting another update.");
 
     // Amount to pay to the bridge node relaying this request from Ethereum to Witnet
@@ -45,7 +45,7 @@ contract PriceFeed is UsingWitnet {
   // The `witnetRequestAccepted` modifier comes with `UsingWitnet` and allows to
   // protect your methods from being called before the request has been successfully
   // relayed into Witnet.
-  function completeUpdate() public witnetRequestAccepted(lastRequestId) {
+  function completeUpdate() external witnetRequestAccepted(lastRequestId) {
     require(pending, "There is no pending update.");
 
     // Read the result of the Witnet request

--- a/contracts/PriceFeedERC2362Wrapper.sol
+++ b/contracts/PriceFeedERC2362Wrapper.sol
@@ -1,0 +1,70 @@
+pragma solidity 0.6.6;
+pragma experimental ABIEncoderV2;
+
+import "adomedianizer/contracts/IERC2362.sol";
+import "witnet-ethereum-bridge/contracts/UsingWitnet.sol";
+import "./PriceFeed.sol";
+import "./requests/BitcoinPrice.sol";
+
+/**
+* @title A thin ERC2362 compliant wrapper around Witnet's basic BTC/USD price feed example.
+* @notice This keeps a reference to an already existing instance of the `PriceFeed` contract, keeps track of when it was
+* updated for the last time, and exposes the value as provided for by ERC2362.
+**/
+contract PriceFeedERC2362Wrapper is UsingWitnet, IERC2362 {
+  address public inner;
+  uint256 public timestamp;
+
+  // This is `keccak256("Price-BTC/USD-3")`
+  bytes32 constant public BTCUSD3ID = bytes32(hex"637b7efb6b620736c247aaa282f3898914c0bef6c12faff0d3fe9d4bea783020");
+
+  /**
+  * @notice Constructs the contract by storing the address to the existing `PriceFeed` contract it is wrapping.
+  **/
+  constructor (address _wrb, address _inner) UsingWitnet(_wrb) public {
+    inner = _inner;
+  }
+
+  /**
+  * @notice Wraps the `requestUpdate` function from the inner `PriceFeed` contract. Additionally, if the request is
+  * submitted successfully, it refunds any value remainder to the transaction initiator.
+  **/
+  function requestUpdate() external payable {
+    // Call `requestUpdate()` in the inner contract.
+    PriceFeed(inner).requestUpdate();
+    // Refund any value remainder to the transaction initiator.
+    msg.sender.transfer(address(this).balance);
+  }
+
+  /**
+  * @notice Wraps the `completeUpdate` function from the inner `PriceFeed` contract and keeps track of when it was
+  * updated for the last time. Note however that calling the `completeUpdate()` function directly on the inner
+  * contract will go unnoticed by this wrapper contract. As a consequence, the poller script for the price feed should
+  * always call this method and not the inner one.
+  **/
+  function completeUpdate() external {
+    PriceFeed innerContract = PriceFeed(inner);
+    // Call `completeUpdate()` in the inner contract.
+    innerContract.completeUpdate();
+    // Set the timestamp of the latest successful completion.
+    if (witnetReadResult(innerContract.lastRequestId()).isOk()) {
+      timestamp = block.timestamp;
+    }
+  }
+
+  /**
+  * @notice Exposes the public data point from the inner `PriceFeed` contract in an ERC2362 compliant way.
+  * @dev Returns error `400` if queried for an unknown data point, and `404` if `completeUpdate` has never been called
+  * successfully before.
+  **/
+  function valueFor(bytes32 _id) external view override returns(int256, uint256, uint256) {
+    // Unsupported data point ID
+    if(_id != BTCUSD3ID) return(0, 0, 400);
+    // No value is yet available for the queried data point ID
+    if (timestamp == 0) return(0, 0, 404);
+
+    int256 value = int256(PriceFeed(inner).bitcoinPrice());
+
+    return(value, timestamp, 200);
+  }
+}

--- a/contracts/PriceFeedERC2362Wrapper.sol
+++ b/contracts/PriceFeedERC2362Wrapper.sol
@@ -21,8 +21,8 @@ contract PriceFeedERC2362Wrapper is UsingWitnet, IERC2362 {
   /**
   * @notice Constructs the contract by storing the address to the existing `PriceFeed` contract it is wrapping.
   **/
-  constructor (address _wrb, address _inner) UsingWitnet(_wrb) public {
-    inner = _inner;
+  constructor (address _wrb, address _priceFeed) UsingWitnet(_wrb) public {
+    inner = _priceFeed;
   }
 
   /**

--- a/flattened-config.js
+++ b/flattened-config.js
@@ -38,15 +38,13 @@ module.exports = {
   // Configure your compilers
   compilers: {
     solc: {
-      // version: "0.5.1",    // Fetch exact version from solc-bin (default: truffle's version)
-      // docker: true,        // Use "0.5.1" you've installed locally with docker (default: false)
-      settings: { // See the solidity docs for advice about optimization and evmVersion
+      settings: {
         optimizer: {
           enabled: true,
-          runs: 200,
-        },
-      //  evmVersion: "byzantium"
+          runs: 200
+        }
       },
+      version: "0.6.6"
     },
   },
   plugins: [

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "verify-flattened": "npx truffle run verify"
   },
   "dependencies": {
+    "adomedianizer": "git+https://github.com/tellor-io/ADOMedianizer.git",
     "openzeppelin-solidity": "^2.4.0",
     "witnet-ethereum-bridge": "git+https://github.com/witnet/witnet-ethereum-bridge",
     "witnet-requests": "git+https://github.com/witnet/witnet-requests-js"

--- a/truffle-config.js
+++ b/truffle-config.js
@@ -56,7 +56,15 @@ module.exports = {
 
   // The `solc` compiler is set to optimize output bytecode with 200 runs, which is the standard these days
   compilers: {
-    solc: { settings: {optimizer: { enabled: true, runs: 200 } }},
+    solc: {
+      settings: {
+        optimizer: {
+          enabled: true,
+          runs: 200
+        }
+      },
+      version: "0.6.6"
+    },
   },
 
   // This plugin allows to verify the source code of your contracts on Etherscan with this command:


### PR DESCRIPTION
Adds a thin ERC2362 compliant wrapper around Witnet's basic BTC/USD price feed example.

The wrapper contract keeps a reference to an already existing instance of the `PriceFeed` contract, keeps track of when it was updated for the last time, and exposes the value as provided for by ERC2362.